### PR TITLE
small change to the `README.md` file. The change corrects the filename for the environment setup instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ TailCI is a powerful, developer-friendly web application framework that seamless
 3. Set up your environment:
 
    ```bash
-   cp env.example .env
+   cp .env.example .env
    ```
 
    Then edit `.env` to configure your database and application settings.


### PR DESCRIPTION
add `.`  in a README.md

This pull request includes a small change to the `README.md` file. The change corrects the filename for the environment setup instructions.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R56): Updated the environment setup instructions to use `.env.example` instead of `env.example`.